### PR TITLE
BufferView Page Fixes and Updates

### DIFF
--- a/documentation/concepts/01_buffer_view.qmd
+++ b/documentation/concepts/01_buffer_view.qmd
@@ -250,34 +250,36 @@ Is specified while making the buffer view as shown in the above example.
 Vector operations use template parameters to specify the vector type (e.g., `ext_vector_t<float, N>` for N elements). The same parameters apply as scalar access, but the operation reads/writes multiple contiguous elements.
 
 ## Scalar vs Vectorized Memory Access
+Compared to scalar access, vectorized access:
+
+- Uses fewer instructions
+- Has better memory bandwidth
+- Has reduced latency
+
+In the figure below, we see that in the vectorized case, there are 4x fewer instructions compared to using scalar access.
 
 ```{=html}
 <div class="mermaid">
-graph LR
-    subgraph "Scalar Access (4 instructions)"
+graph TD
+    subgraph "Scalar Access"
         S1["Load float[0]"] --> R1["Register 1"]
         S2["Load float[1]"] --> R2["Register 2"]
         S3["Load float[2]"] --> R3["Register 3"]
         S4["Load float[3]"] --> R4["Register 4"]
     end
     
-    subgraph "Vectorized Access (1 instruction)"
+    subgraph "Vectorized Access"
         V1["Load float4[0]"] --> VR["Vector Register<br/>(4 floats)"]
     end
-    
-    subgraph "Performance Impact"
-        Perf["4x fewer instructions<br/>Better memory bandwidth<br/>Reduced latency"]
-    end
-    
-    R1 & R2 & R3 & R4 --> Perf
-    VR --> Perf
+
+    R1 & R2 & R3 & R4 
+    VR
     
     style S1 fill:#fee2e2,stroke:#ef4444,stroke-width:2px
     style S2 fill:#fee2e2,stroke:#ef4444,stroke-width:2px
     style S3 fill:#fee2e2,stroke:#ef4444,stroke-width:2px
     style S4 fill:#fee2e2,stroke:#ef4444,stroke-width:2px
     style V1 fill:#d1fae5,stroke:#10b981,stroke-width:2px
-    style Perf fill:#fef3c7,stroke:#f59e0b,stroke-width:2px
 </div>
 ```
 

--- a/documentation/concepts/01_buffer_view.qmd
+++ b/documentation/concepts/01_buffer_view.qmd
@@ -164,38 +164,6 @@ __device__ void example_buffer_creation()
 }
 ```
 
-### Python vs C++ Key Differences
-
-#### 1. **Compile-Time vs Runtime**
-- **C++**: BufferView uses template metaprogramming with compile-time constants
-  - Size is encoded in the type: `number<8>{}`
-  - Address space is a template parameter
-  - Enables aggressive compiler optimizations
-- **Python**: Everything is runtime
-  - Size is a regular integer
-  - Address space is an enum value
-  - Designed for learning and experimentation
-
-#### 2. **Memory Management**
-- **C++**: Direct pointer to GPU memory
-  - No memory allocation - uses existing memory
-  - Pointer arithmetic for addressing
-  - Zero-copy access to device memory
-- **Python**: NumPy array simulation
-  - Uses host memory to simulate GPU memory
-  - Python manages memory lifetime
-  - Educational approximation of GPU behavior
-
-#### 3. **Type System**
-- **C++**: Strong compile-time typing
-  ```cpp
-  buffer_view<float*, address_space_enum::global>  // Type encodes everything
-  ```
-- **Python**: Dynamic typing with runtime checks
-  ```python
-  BufferView  # Generic class, properties stored as members
-  ```
-
 ### Zero Value Mode
 ```cpp
 // Basic buffer view creation with automatic zero for invalid elements

--- a/documentation/concepts/01_buffer_view.qmd
+++ b/documentation/concepts/01_buffer_view.qmd
@@ -560,6 +560,7 @@ __device__ void example_atomic_operations()
 # Summary
 
 BufferView provides:
+
 - **Unified Interface**: Same API for all memory spaces
 - **Type Safety**: Address space encoded in type (C++)
 - **Performance**: Vectorized operations and optimal access patterns


### PR DESCRIPTION
### Summary of Changes:
This PR fixes some formatting issues and duplication in the BufferView page. It also updates a the "Scalar vs Vectorized Memory Access" section to provide more clarity into the benefits of vectorized access.

### Description of Changes:
**1. Updates the "Scalar vs Vectorized Memory Access" section.** 

- Without my changes, the section is shown in the image below. That said, the graph seems to imply that scalar access has the same performance impact as vectorized memory access, which is not the case.

<img width="1024" height="804" alt="image" src="https://github.com/user-attachments/assets/082802c7-61d8-4275-8bc1-d25b5619820e" />

- Instead, rather than including the performance impact in the diagram, I have added some text to describe the performance impact. Resulting in the following section:

<img width="1287" height="612" alt="image" src="https://github.com/user-attachments/assets/86535a4e-652c-4a80-afbd-f6dd5dee9acc" />

**2. Removes duplicate "Python vs C++ Key Differences" section**

- In the current version, there are two identical sections of "Python vs C++ Key Differences". I have removed one of them.


**3. Fixed formatting of list in Summary section:**

- Without my changes, the list looks like:
<img width="1203" height="104" alt="image" src="https://github.com/user-attachments/assets/6fdc7c58-1831-4869-b47b-023410600588" />

- My changes fix the formatting, resulting in the following:
<img width="768" height="229" alt="image" src="https://github.com/user-attachments/assets/a0e57f05-9849-44ca-bbbc-212de8e1f220" />


